### PR TITLE
feat: SDK update for version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+* Fixed: Permission and access-control wording in skills updated for TablesDB (`row`/`table` instead of `document`/`collection`)
+
 ## 0.2.0
 
 * Updated: Compatible with Appwrite server `1.9.x`

--- a/skills/appwrite-dart/SKILL.md
+++ b/skills/appwrite-dart/SKILL.md
@@ -447,7 +447,7 @@ try {
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```dart
 import 'package:appwrite/appwrite.dart';
@@ -486,7 +486,7 @@ final file = await storage.createFile(
 );
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-dotnet/SKILL.md
+++ b/skills/appwrite-dotnet/SKILL.md
@@ -362,7 +362,7 @@ catch (AppwriteException e)
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```csharp
 using Appwrite;
@@ -396,7 +396,7 @@ var file = await storage.CreateFile("[BUCKET_ID]", ID.Unique(),
     });
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-go/SKILL.md
+++ b/skills/appwrite-go/SKILL.md
@@ -418,7 +418,7 @@ if err != nil {
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `permission` and `role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `permission` and `role` helpers.
 
 ```go
 import (
@@ -459,7 +459,7 @@ f, err := service.CreateFile(
 )
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-kotlin/SKILL.md
+++ b/skills/appwrite-kotlin/SKILL.md
@@ -499,7 +499,7 @@ try {
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```kotlin
 import io.appwrite.Permission
@@ -538,7 +538,7 @@ val file = storage.createFile(
 )
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-php/SKILL.md
+++ b/skills/appwrite-php/SKILL.md
@@ -347,7 +347,7 @@ try {
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```php
 use Appwrite\Permission;
@@ -377,7 +377,7 @@ $file = $storage->createFile('[BUCKET_ID]', ID::unique(), InputFile::withPath('/
 ]);
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-python/SKILL.md
+++ b/skills/appwrite-python/SKILL.md
@@ -370,7 +370,7 @@ except AppwriteException as e:
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```python
 from appwrite.permission import Permission
@@ -400,7 +400,7 @@ file = storage.create_file('[BUCKET_ID]', ID.unique(), InputFile.from_path('/pat
 ])
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-ruby/SKILL.md
+++ b/skills/appwrite-ruby/SKILL.md
@@ -373,7 +373,7 @@ end
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```ruby
 # Permission and Role are included in the main require
@@ -413,7 +413,7 @@ file = storage.create_file(
 )
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-swift/SKILL.md
+++ b/skills/appwrite-swift/SKILL.md
@@ -434,7 +434,7 @@ do {
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```swift
 import Appwrite
@@ -473,7 +473,7 @@ let file = try await storage.createFile(
 )
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)

--- a/skills/appwrite-typescript/SKILL.md
+++ b/skills/appwrite-typescript/SKILL.md
@@ -658,7 +658,7 @@ try {
 
 ## Permissions & Roles (Critical)
 
-Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, **no user has access** unless permissions are explicitly set at the row/file level or inherited from the table/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
 
 ```typescript
 import { Permission, Role } from 'appwrite';
@@ -697,7 +697,7 @@ const file = await storage.createFile({
 });
 ```
 
-> **When to set permissions:** Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+> **When to set permissions:** Set row/file-level permissions when you need per-resource access control. If all rows in a table share the same rules, configure permissions at the table/bucket level and leave row permissions empty.
 
 > **Common mistakes:**
 > - **Forgetting permissions** — the resource becomes inaccessible to all users (including the creator)


### PR DESCRIPTION
This PR contains updates to the SDK for version 0.2.1.

## What's Changed

* Fixed: Permission and access-control wording in skills updated for TablesDB (`row`/`table` instead of `document`/`collection`)